### PR TITLE
Use any registered TableNameResolver in getOverriddenTableName.

### DIFF
--- a/src/main/java/org/socialsignin/spring/data/dynamodb/core/DynamoDBOperations.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/core/DynamoDBOperations.java
@@ -31,7 +31,7 @@ public interface DynamoDBOperations {
 	public void delete(Object entity);
 	public void batchDelete(List<?> entities);
 
-	public String getOverriddenTableName(String tableName);
+	public <T> String getOverriddenTableName(Class<T> domainClass, String tableName);
 
 
 }

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/core/DynamoDBTemplate.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/core/DynamoDBTemplate.java
@@ -194,13 +194,15 @@ public class DynamoDBTemplate implements DynamoDBOperations,ApplicationContextAw
 	}
 
 	@Override
-	public String getOverriddenTableName(String tableName) {
+	public <T> String getOverriddenTableName(Class<T> domainClass, String tableName) {
 		if (dynamoDBMapperConfig.getTableNameOverride() != null) {
 			if (dynamoDBMapperConfig.getTableNameOverride().getTableName() != null) {
 				tableName = dynamoDBMapperConfig.getTableNameOverride().getTableName();
 			} else {
 				tableName = dynamoDBMapperConfig.getTableNameOverride().getTableNamePrefix() + tableName;
 			}
+		} else if (dynamoDBMapperConfig.getTableNameResolver() != null) {
+		  tableName = dynamoDBMapperConfig.getTableNameResolver().getTableName(domainClass, dynamoDBMapperConfig);
 		}
 
 		return tableName;

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBEntityWithHashAndRangeKeyCriteria.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBEntityWithHashAndRangeKeyCriteria.java
@@ -200,7 +200,7 @@ public class DynamoDBEntityWithHashAndRangeKeyCriteria<T, ID extends Serializabl
 	protected Query<T> buildFinderQuery(DynamoDBOperations dynamoDBOperations) {
 		if (isApplicableForQuery()) {
 			if (isApplicableForGlobalSecondaryIndex()) {
-				String tableName = dynamoDBOperations.getOverriddenTableName(entityInformation.getDynamoDBTableName());
+				String tableName = dynamoDBOperations.getOverriddenTableName(clazz, entityInformation.getDynamoDBTableName());
 				QueryRequest queryRequest = buildQueryRequest(tableName, getGlobalSecondaryIndexName(),
 						getHashKeyAttributeName(), getRangeKeyAttributeName(), this.getRangeKeyPropertyName(),
 						getHashKeyConditions(), getRangeKeyConditions());
@@ -218,7 +218,7 @@ public class DynamoDBEntityWithHashAndRangeKeyCriteria<T, ID extends Serializabl
 	protected Query<Long> buildFinderCountQuery(DynamoDBOperations dynamoDBOperations,boolean pageQuery) {
 		if (isApplicableForQuery()) {
 			if (isApplicableForGlobalSecondaryIndex()) {
-				String tableName = dynamoDBOperations.getOverriddenTableName(entityInformation.getDynamoDBTableName());
+				String tableName = dynamoDBOperations.getOverriddenTableName(clazz, entityInformation.getDynamoDBTableName());
 				QueryRequest queryRequest = buildQueryRequest(tableName, getGlobalSecondaryIndexName(),
 						getHashKeyAttributeName(), getRangeKeyAttributeName(), this.getRangeKeyPropertyName(),
 						getHashKeyConditions(), getRangeKeyConditions());

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBEntityWithHashKeyOnlyCriteria.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBEntityWithHashKeyOnlyCriteria.java
@@ -58,7 +58,7 @@ public class DynamoDBEntityWithHashKeyOnlyCriteria<T, ID extends Serializable> e
 		if (isApplicableForGlobalSecondaryIndex()) {
 
 			List<Condition> hashKeyConditions = getHashKeyConditions();
-			QueryRequest queryRequest = buildQueryRequest(dynamoDBOperations.getOverriddenTableName(entityInformation.getDynamoDBTableName()),
+			QueryRequest queryRequest = buildQueryRequest(dynamoDBOperations.getOverriddenTableName(clazz, entityInformation.getDynamoDBTableName()),
 					getGlobalSecondaryIndexName(), getHashKeyAttributeName(), null, null, hashKeyConditions, null);
 			return new MultipleEntityQueryRequestQuery<T>(dynamoDBOperations,entityInformation.getJavaType(), queryRequest);
 		} else {
@@ -70,7 +70,7 @@ public class DynamoDBEntityWithHashKeyOnlyCriteria<T, ID extends Serializable> e
 		if (isApplicableForGlobalSecondaryIndex()) {
 
 			List<Condition> hashKeyConditions = getHashKeyConditions();
-			QueryRequest queryRequest = buildQueryRequest(dynamoDBOperations.getOverriddenTableName(entityInformation.getDynamoDBTableName()),
+			QueryRequest queryRequest = buildQueryRequest(dynamoDBOperations.getOverriddenTableName(clazz, entityInformation.getDynamoDBTableName()),
 					getGlobalSecondaryIndexName(), getHashKeyAttributeName(), null, null, hashKeyConditions, null);
 			return new QueryRequestCountQuery<T>(dynamoDBOperations, entityInformation.getJavaType(), queryRequest);
 

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/support/SimpleDynamoDBCrudRepository.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/support/SimpleDynamoDBCrudRepository.java
@@ -91,7 +91,7 @@ public class SimpleDynamoDBCrudRepository<T, ID extends Serializable>
 			}
 		}
 		keyPairsMap.put(domainType, keyPairs);
-		return (List<T>) dynamoDBOperations.batchLoad(keyPairsMap).get(dynamoDBOperations.getOverriddenTableName(entityInformation.getDynamoDBTableName()));
+		return (List<T>) dynamoDBOperations.batchLoad(keyPairsMap).get(dynamoDBOperations.getOverriddenTableName(domainType, entityInformation.getDynamoDBTableName()));
 	}
 
 	protected T load(ID id) {

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/core/DynamoDBTemplateUnitTest.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/core/DynamoDBTemplateUnitTest.java
@@ -15,6 +15,8 @@ import org.socialsignin.spring.data.dynamodb.domain.sample.User;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.TableNameResolver;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DynamoDBTemplateUnitTest {
@@ -56,17 +58,30 @@ public class DynamoDBTemplateUnitTest {
 	@Test
 	public void testGetOverriddenTableName_WhenConfigIsNull()
 	{
-		String overriddenTableName = dynamoDBTemplate.getOverriddenTableName("someTableName");
+		String overriddenTableName = dynamoDBTemplate.getOverriddenTableName(Object.class, "someTableName");
 		Assert.assertEquals("someTableName", overriddenTableName);
 	}
 	
-	@Test
-	public void testGetOverriddenTableName()
-	{
-		String overriddenTableName = dynamoDBTemplate.getOverriddenTableName("someTableName");
-		Assert.assertEquals("someTableName", overriddenTableName);
-	}
-	
+    @Test
+    public void testGetOverriddenTableName()
+    {
+        String overriddenTableName = dynamoDBTemplate.getOverriddenTableName(Object.class, "someTableName");
+        Assert.assertEquals("someTableName", overriddenTableName);
+    }
+
+    @Test
+    public void testGetOverriddenTableName_WithTableNameResolver()
+    {
+        DynamoDBMapperConfig dynamoDBMapperConfig = Mockito.mock(DynamoDBMapperConfig.class);
+        TableNameResolver tableNameResolver = Mockito.mock(TableNameResolver.class);
+        Mockito.when(tableNameResolver.getTableName(Object.class, dynamoDBMapperConfig)).thenReturn(
+            "someOtherTableName");
+        Mockito.when(dynamoDBMapperConfig.getTableNameResolver()).thenReturn(tableNameResolver);
+        dynamoDBTemplate.setDynamoDBMapperConfig(dynamoDBMapperConfig);
+        String overriddenTableName = dynamoDBTemplate.getOverriddenTableName(Object.class, "someTableName");
+        Assert.assertEquals("someOtherTableName", overriddenTableName);
+    }
+
 	@Test
 	public void testLoadByHashKey_WhenDynamoDBMapperReturnsNull()
 	{

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/repository/query/PartTreeDynamoDBQueryUnitTest.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/repository/query/PartTreeDynamoDBQueryUnitTest.java
@@ -2154,7 +2154,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 		Mockito.when(mockUserQueryResults.size()).thenReturn(1);
 		Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 		.thenReturn(mockUserQueryResults);
-		Mockito.when(mockDynamoDBOperations.getOverriddenTableName("user")).thenReturn("user");
+		Mockito.when(mockDynamoDBOperations.getOverriddenTableName(User.class, "user")).thenReturn("user");
 
 
 		// Execute the query
@@ -2232,7 +2232,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 			Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 			.thenReturn(mockUserQueryResults);
 			Mockito.when(mockUserEntityMetadata.getDynamoDBTableName()).thenReturn("user");
-			Mockito.when(mockDynamoDBOperations.getOverriddenTableName("user")).thenReturn("user");
+			Mockito.when(mockDynamoDBOperations.getOverriddenTableName(User.class, "user")).thenReturn("user");
 
 
 			// Execute the query
@@ -2310,7 +2310,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 			Mockito.when(mockPlaylistQueryResults.size()).thenReturn(1);
 			Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 			.thenReturn(mockPlaylistQueryResults);
-			Mockito.when(mockDynamoDBOperations.getOverriddenTableName("playlist")).thenReturn("playlist");
+			Mockito.when(mockDynamoDBOperations.getOverriddenTableName(Playlist.class, "playlist")).thenReturn("playlist");
 
 
 			// Execute the query
@@ -2380,7 +2380,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 					Mockito.when(mockPlaylistQueryResults.size()).thenReturn(1);
 					Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 					.thenReturn(mockPlaylistQueryResults);
-					Mockito.when(mockDynamoDBOperations.getOverriddenTableName("playlist")).thenReturn("playlist");
+					Mockito.when(mockDynamoDBOperations.getOverriddenTableName(Playlist.class, "playlist")).thenReturn("playlist");
 
 
 					// Execute the query
@@ -2455,7 +2455,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 					Mockito.when(mockPlaylistQueryResults.size()).thenReturn(1);
 					Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 					.thenReturn(mockPlaylistQueryResults);
-					Mockito.when(mockDynamoDBOperations.getOverriddenTableName("playlist")).thenReturn("playlist");
+					Mockito.when(mockDynamoDBOperations.getOverriddenTableName(Playlist.class, "playlist")).thenReturn("playlist");
 
 
 					// Execute the query
@@ -2536,7 +2536,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 					Mockito.when(mockPlaylistQueryResults.size()).thenReturn(1);
 					Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 					.thenReturn(mockPlaylistQueryResults);
-					Mockito.when(mockDynamoDBOperations.getOverriddenTableName("playlist")).thenReturn("playlist");
+					Mockito.when(mockDynamoDBOperations.getOverriddenTableName(Playlist.class, "playlist")).thenReturn("playlist");
 
 
 					// Execute the query
@@ -2621,7 +2621,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 					Mockito.when(mockPlaylistQueryResults.size()).thenReturn(1);
 					Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 					.thenReturn(mockPlaylistQueryResults);
-					Mockito.when(mockDynamoDBOperations.getOverriddenTableName("playlist")).thenReturn("playlist");
+					Mockito.when(mockDynamoDBOperations.getOverriddenTableName(Playlist.class, "playlist")).thenReturn("playlist");
 
 
 					// Execute the query
@@ -2705,7 +2705,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 					Mockito.when(mockPlaylistQueryResults.size()).thenReturn(1);
 					Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 					.thenReturn(mockPlaylistQueryResults);
-					Mockito.when(mockDynamoDBOperations.getOverriddenTableName("playlist")).thenReturn("playlist");
+					Mockito.when(mockDynamoDBOperations.getOverriddenTableName(Playlist.class, "playlist")).thenReturn("playlist");
 
 
 					// Execute the query
@@ -2789,7 +2789,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 					Mockito.when(mockPlaylistQueryResults.size()).thenReturn(1);
 					Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 					.thenReturn(mockPlaylistQueryResults);
-					Mockito.when(mockDynamoDBOperations.getOverriddenTableName("playlist")).thenReturn("playlist");
+					Mockito.when(mockDynamoDBOperations.getOverriddenTableName(Playlist.class, "playlist")).thenReturn("playlist");
 
 
 					// Execute the query
@@ -2871,7 +2871,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 					Mockito.when(mockPlaylistQueryResults.size()).thenReturn(1);
 					Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 					.thenReturn(mockPlaylistQueryResults);
-					Mockito.when(mockDynamoDBOperations.getOverriddenTableName("playlist")).thenReturn("playlist");
+					Mockito.when(mockDynamoDBOperations.getOverriddenTableName(Playlist.class, "playlist")).thenReturn("playlist");
 
 
 					// Execute the query
@@ -2952,7 +2952,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 					Mockito.when(mockPlaylistQueryResults.size()).thenReturn(1);
 					Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 					.thenReturn(mockPlaylistQueryResults);
-					Mockito.when(mockDynamoDBOperations.getOverriddenTableName("playlist")).thenReturn("playlist");
+					Mockito.when(mockDynamoDBOperations.getOverriddenTableName(Playlist.class, "playlist")).thenReturn("playlist");
 
 
 					// Execute the query
@@ -3037,7 +3037,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 					Mockito.when(mockPlaylistQueryResults.size()).thenReturn(1);
 					Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 					.thenReturn(mockPlaylistQueryResults);
-					Mockito.when(mockDynamoDBOperations.getOverriddenTableName("playlist")).thenReturn("playlist");
+					Mockito.when(mockDynamoDBOperations.getOverriddenTableName(Playlist.class, "playlist")).thenReturn("playlist");
 
 
 					// Execute the query
@@ -3121,7 +3121,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 					Mockito.when(mockPlaylistQueryResults.size()).thenReturn(1);
 					Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 					.thenReturn(mockPlaylistQueryResults);
-					Mockito.when(mockDynamoDBOperations.getOverriddenTableName("playlist")).thenReturn("playlist");
+					Mockito.when(mockDynamoDBOperations.getOverriddenTableName(Playlist.class, "playlist")).thenReturn("playlist");
 
 
 					// Execute the query
@@ -3206,7 +3206,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 					Mockito.when(mockUserQueryResults.size()).thenReturn(1);
 					Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 					.thenReturn(mockUserQueryResults);
-					Mockito.when(mockDynamoDBOperations.getOverriddenTableName("user")).thenReturn("user");
+					Mockito.when(mockDynamoDBOperations.getOverriddenTableName(User.class, "user")).thenReturn("user");
 
 
 					// Execute the query
@@ -3294,7 +3294,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 					Mockito.when(mockUserQueryResults.size()).thenReturn(1);
 					Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 					.thenReturn(mockUserQueryResults);
-					Mockito.when(mockDynamoDBOperations.getOverriddenTableName("user")).thenReturn("user");
+					Mockito.when(mockDynamoDBOperations.getOverriddenTableName(User.class, "user")).thenReturn("user");
 
 
 					// Execute the query
@@ -3370,7 +3370,7 @@ public class PartTreeDynamoDBQueryUnitTest {
 					Mockito.when(mockUserQueryResults.size()).thenReturn(1);
 					Mockito.when(mockDynamoDBOperations.query(classCaptor.capture(), queryCaptor.capture()))
 					.thenReturn(mockUserQueryResults);
-					Mockito.when(mockDynamoDBOperations.getOverriddenTableName("user")).thenReturn("user");
+					Mockito.when(mockDynamoDBOperations.getOverriddenTableName(User.class, "user")).thenReturn("user");
 
 
 					// Execute the query


### PR DESCRIPTION
This adds consideration of any TableNameResolver in the dynamoDBMapperConfig in
the getOverriddenTableName method. Without this change it is not possible to run
certain types of queries against tables whose names are not known at build time.
Registering a TableNameResolver did not help since it is a mapper concept and
these queries are run using QueryRequests directly through the client.