### PR TITLE
Added setters, equals and hashcode to README as well as a fully worki…

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,33 @@ public class User {
 	return lastName;
   }
        
-  // Also add setters
+  public void setId(String id) {
+          this.id = id;
+      }
+  
+  public void setFirstName(String firstName) {
+      this.firstName = firstName;
+  }
+
+  public void setLastName(String lastName) {
+      this.lastName = lastName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+
+      User user = (User) o;
+
+      return id.equals(user.id);
+
+  }
+
+  @Override
+  public int hashCode() {
+      return id.hashCode();
+  }
 }
 ```
 
@@ -177,22 +203,57 @@ And finally write a test client
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = { 
     PropertyPlaceholderAutoConfiguration.class, DynamoDBConfig.class})
-  public class UserRepositoryIntegrationTest {
+    public class UserRepositoryIntegrationTest {
      
-  @Autowired UserRepository repository;
-     
-  @Test
-  public void sampleTestCase() {
-    User dave = new User("Dave", "Matthews");
-    repository.save(user);
-         
-    User carter = new User("Carter", "Beauford");
-    repository.save(carter);
-         
-    List<User> result = repository.findByLastName("Matthews");
-    assertThat(result.size(), is(1));
-    assertThat(result, hasItem(dave));
-  }
+    private static final String KEY_NAME = "id";
+    private static final Long READ_CAPACITY_UNITS = 5L;
+    private static final Long WRITE_CAPACITY_UNITS = 5L;
+    
+    @Autowired
+    UserRepository repository;
+    
+    @Autowired
+    private AmazonDynamoDB amazonDynamoDB;
+    
+    @Before
+    public void init() throws Exception{
+    
+        ListTablesResult listTablesResult = amazonDynamoDB.listTables();
+    
+        listTablesResult.getTableNames().stream().
+                filter(tableName -> tableName.equals(User.TABLE_NAME)).forEach(tableName -> {
+            amazonDynamoDB.deleteTable(tableName);
+        });
+    
+        List<AttributeDefinition> attributeDefinitions = new ArrayList<AttributeDefinition>();
+        attributeDefinitions.add(new AttributeDefinition().withAttributeName(KEY_NAME).withAttributeType("S"));
+    
+        List<KeySchemaElement> keySchemaElements = new ArrayList<KeySchemaElement>();
+        keySchemaElements.add(new KeySchemaElement().withAttributeName(KEY_NAME).withKeyType(KeyType.HASH));
+    
+        CreateTableRequest request = new CreateTableRequest()
+                .withTableName(TABLE_NAME)
+                .withKeySchema(keySchemaElements)
+                .withAttributeDefinitions(attributeDefinitions)
+                .withProvisionedThroughput(new ProvisionedThroughput().withReadCapacityUnits(READ_CAPACITY_UNITS)
+                        .withWriteCapacityUnits(WRITE_CAPACITY_UNITS));
+    
+        amazonDynamoDB.createTable(request);
+    
+    }
+    
+    @Test
+    public void sampleTestCase() {
+        User dave = new User("Dave", "Matthews");
+        repository.save(dave);
+    
+        User carter = new User("Carter", "Beauford");
+        repository.save(carter);
+    
+        List<User> result = repository.findByLastName("Matthews");
+        Assert.assertThat(result.size(), is(1));
+        Assert.assertThat(result, hasItem(dave));
+    }
 }
 ```
  


### PR DESCRIPTION
Hi, I've improved the README file a bit so that it shows setters and the equals and hashcode (without equals, the unit test was failing when comparing the Matthew User objects). 

I've also written a unit test that destroys and recreates the table each time. This has been tested on local dynamodb, running on localhost:8000