### PR TITLE
Fixed the bug with XML configuration where DynamoDBMapperConfig was n…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.derjust</groupId>
     <artifactId>spring-data-dynamodb</artifactId>
-    <version>4.5.1-SNAPSHOT</version>
+    <version>4.5.2-SNAPSHOT</version>
     <name>Spring Data DynamoDb</name>
     <description>Spring Data module providing support for DynamoDb repositories.</description>
     <url>http://github.com/derjust/spring-data-dynamodb</url>

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/config/DynamoDBRepositoryConfigExtension.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/config/DynamoDBRepositoryConfigExtension.java
@@ -33,9 +33,9 @@ public class DynamoDBRepositoryConfigExtension extends RepositoryConfigurationEx
 
 	private static final String DEFAULT_AMAZON_DYNAMO_DB_BEAN_NAME = "amazonDynamoDB";
 
-	private static final String DYNAMO_DB_MAPPER_CONFIG_REF = "dynamoDBMapperConfig";
+	private static final String DYNAMO_DB_MAPPER_CONFIG_REF = "dynamodb-mapper-config-ref";
 	
-	private static final String DYNAMO_DB_OPERATIONS_REF = "dynamoDBOperations";
+	private static final String DYNAMO_DB_OPERATIONS_REF = "dynamodb-operations-ref";
 
 
 	private static final String AMAZON_DYNAMODB_REF = "amazon-dynamodb-ref";


### PR DESCRIPTION
There was a bug where when DynamoDBMapperConfig when passed from Spring config XML file was never picked up due to a typo.

 <bean id="dynamoDBMapperConfig" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean"  >    	
        <property name="targetObject">
		    <bean class="com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.TableNameOverride" factory-method="withTableNamePrefix">    	
		    	<constructor-arg value="Qa_"></constructor-arg>		    	 		
			</bean>
		</property>			
		<property name="targetMethod" ><value>config</value></property>
    </bean>
	
	<bean id="amazonDynamoDB" class="com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient">
		<constructor-arg ref="amazonAWSCredentials" />		
		<property name="endpoint" value="${amazon.dynamodb.endpoint}" />
	</bean>
	
    
	<dynamodb:repositories
		base-package="nz.co.mightyriverpower.consumptiondata.dynamodb.repository"
		amazon-dynamodb-ref="amazonDynamoDB"  **dynamodb-mapper-config-ref**="dynamoDBMapperConfig" dynamodb-operations-ref=""/>

This bug fix will allow user to prefix or change dynamo db table names, using XML configuration instead of switching to Java code.