### PR TITLE
Fix in case DynamoDBMapper is already provided

### DIFF
--- a/src/main/java/org/socialsignin/spring/data/dynamodb/core/DynamoDBTemplate.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/core/DynamoDBTemplate.java
@@ -53,7 +53,7 @@ public class DynamoDBTemplate implements DynamoDBOperations, ApplicationContextA
 	
 	DynamoDBTemplate(AmazonDynamoDB amazonDynamoDB, DynamoDBMapperConfig dynamoDBMapperConfig, DynamoDBMapper dynamoDBMapper) {
        this.amazonDynamoDB = amazonDynamoDB;
-        if (dynamoDBMapperConfig == null) {
+       if (dynamoDBMapper == null && dynamoDBMapperConfig == null)
             this.dynamoDBMapperConfig = DynamoDBMapperConfig.DEFAULT;
             this.dynamoDBMapper = new DynamoDBMapper(amazonDynamoDB);
             // Mapper must be null as it could not have been constructed without a Config


### PR DESCRIPTION
Fix in case dynamoDbMapper is already provided,w e dont need to check for dynamodDbMapperCofig or the assert

references issue #91 