### PR TITLE
Respect the pagination size for queries

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -33,6 +33,9 @@
       <action dev="derjust" issue="108" type="fix" date="2018-01-14">
         Opened constructor and fixed NPE in case of missing DynamoDBConfig
       </action>
+      <action dev="derjust" issue="89" type="add" date="2018-01-17">
+        Added basic support for Pageable
+      </action>
     </release>
     <release version="5.0.1" date="2018-01-06" description="Maintenance release">
       <action dev="derjust" issue="68" type="fix" date="2017-12-01" >

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/AbstractDynamoDBQueryCriteria.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/AbstractDynamoDBQueryCriteria.java
@@ -29,6 +29,7 @@ import org.socialsignin.spring.data.dynamodb.marshaller.Date2IsoDynamoDBMarshall
 import org.socialsignin.spring.data.dynamodb.marshaller.Instant2IsoDynamoDBMarshaller;
 import org.socialsignin.spring.data.dynamodb.query.Query;
 import org.socialsignin.spring.data.dynamodb.repository.support.DynamoDBEntityInformation;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.domain.Sort.Order;
@@ -66,6 +67,7 @@ public abstract class AbstractDynamoDBQueryCriteria<T, ID> implements DynamoDBQu
 	protected Object hashKeyPropertyValue;
 	protected String globalSecondaryIndexName;
 	protected Sort sort;
+	protected Pageable pageable;
 
 	public abstract boolean isApplicableForLoad();
 
@@ -132,7 +134,14 @@ public abstract class AbstractDynamoDBQueryCriteria<T, ID> implements DynamoDBQu
 			queryRequest.setSelect(Select.ALL_PROJECTED_ATTRIBUTES);
 			applySortIfSpecified(queryRequest, new ArrayList<String>(new HashSet<String>(allowedSortProperties)));
 		}
+		applyPageableIfSpecified(queryRequest);
 		return queryRequest;
+	}
+
+	private void applyPageableIfSpecified(QueryRequest queryRequest) {
+		if (pageable.isPaged()) {
+			queryRequest.setLimit(pageable.getPageSize());
+		}
 	}
 
 	protected void applySortIfSpecified(DynamoDBQueryExpression<T> queryExpression, List<String> permittedPropertyNames) {
@@ -685,6 +694,12 @@ public abstract class AbstractDynamoDBQueryCriteria<T, ID> implements DynamoDBQu
 	@Override
 	public DynamoDBQueryCriteria<T, ID> withSort(Sort sort) {
 		this.sort = sort;
+		return this;
+	}
+
+	@Override
+	public DynamoDBQueryCriteria<T, ID> withPageable(Pageable pageable) {
+		this.pageable = pageable;
 		return this;
 	}
 

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBQueryCreator.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBQueryCreator.java
@@ -18,16 +18,20 @@ package org.socialsignin.spring.data.dynamodb.repository.query;
 import org.socialsignin.spring.data.dynamodb.core.DynamoDBOperations;
 import org.socialsignin.spring.data.dynamodb.query.Query;
 import org.socialsignin.spring.data.dynamodb.repository.support.DynamoDBEntityInformation;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.repository.query.ParameterAccessor;
 import org.springframework.data.repository.query.parser.PartTree;
 
 public class DynamoDBQueryCreator<T,ID> extends AbstractDynamoDBQueryCreator<T, ID,T> {
 
+	private final Pageable pageable;
+
 	public DynamoDBQueryCreator(PartTree tree,
 			DynamoDBEntityInformation<T, ID> entityMetadata,
 			DynamoDBOperations dynamoDBOperations) {
 		super(tree, entityMetadata, dynamoDBOperations);
+		pageable = Pageable.unpaged();
 	}
 
 	public DynamoDBQueryCreator(PartTree tree,
@@ -35,13 +39,16 @@ public class DynamoDBQueryCreator<T,ID> extends AbstractDynamoDBQueryCreator<T, 
 			DynamoDBEntityInformation<T, ID> entityMetadata,
 			DynamoDBOperations dynamoDBOperations) {
 		super(tree, parameterAccessor, entityMetadata, dynamoDBOperations);
+		pageable = parameterAccessor.getPageable();
 	}
-	
+
 	@Override
 	protected Query<T> complete(DynamoDBQueryCriteria<T, ID> criteria, Sort sort) {
 		if (sort != null) {
 			criteria.withSort(sort);
 		}
+
+		criteria.withPageable(pageable);
 
 		return criteria.buildQuery(dynamoDBOperations);
 

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBQueryCriteria.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBQueryCriteria.java
@@ -18,6 +18,7 @@ package org.socialsignin.spring.data.dynamodb.repository.query;
 import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
 import org.socialsignin.spring.data.dynamodb.core.DynamoDBOperations;
 import org.socialsignin.spring.data.dynamodb.query.Query;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
 /**
@@ -37,7 +38,9 @@ public interface DynamoDBQueryCriteria<T, ID> {
 	DynamoDBQueryCriteria<T, ID> withPropertyBetween(String segment, Object value1, Object value2, Class<?> type);
 
 	DynamoDBQueryCriteria<T, ID> withSort(Sort sort);
-
+	
+	DynamoDBQueryCriteria<T, ID> withPageable(Pageable pageable);
+	
 	Query<T> buildQuery(DynamoDBOperations dynamoDBOperations);
 
 	Query<Long> buildCountQuery(DynamoDBOperations dynamoDBOperations, boolean pageQuery);


### PR DESCRIPTION
This change respects the pagination size as provided from a Pageable
object given to a findXXX method.
Mostly important in conjunction with lazy list processing via
```java
DynamoDBMapperConfig.Builder builder = new DynamoDBMapperConfig.Builder();
builder.setPaginationLoadingStrategy(PaginationLoadingStrategy.ITERATION_ONLY);
```
as this loads the result set of a query page-by-page.
Also see the comments in
`com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList<T>` as
used by
`org.socialsignin.spring.data.dynamodb.core.DynamoDBTemplate.query(Class<T>,
QueryRequest)`