### PR TITLE
Local Unit testing with real DynamoDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 
         <cdi.version>1.2</cdi.version>
         <slf4j-test.version>1.2.0</slf4j-test.version>
+        <sqlite4java.version>1.0.392</sqlite4java.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -95,6 +96,12 @@
                 <version>${aws-java-sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>DynamoDBLocal</artifactId>
+                <version>[1.11,2.0)</version>
             </dependency>
 
             <dependency>
@@ -151,6 +158,11 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>DynamoDBLocal</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -413,6 +425,43 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>com.almworks.sqlite4java</groupId>
+                                    <artifactId>${sqlite4java.artifactId}</artifactId>
+                                    <version>${sqlite4java.version}</version>
+                                    <type>${sqlite4java.type}</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <property>
+                            <name>sqlite4java.library.path</name>
+                            <value>${project.build.directory}/lib</value>
+                        </property>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
@@ -444,6 +493,11 @@
             <id>spring-libs-snapshot</id>
             <url>http://repo.springsource.org/libs-snapshot</url>
         </repository>
+        <repository>
+            <id>dynamodb-local-oregon</id>
+            <name>DynamoDB Local Release Repository</name>
+            <url>https://s3-us-west-2.amazonaws.com/dynamodb-local/release</url>
+        </repository>
     </repositories>
 
     <pluginRepositories>
@@ -457,6 +511,70 @@
     </pluginRepositories>
 
     <profiles>
+        <profile>
+            <id>mac</id>
+            <activation>
+                <os>
+                    <family>mac</family>
+                </os>
+            </activation>
+            <properties>
+                <sqlite4java.artifactId>libsqlite4java-osx</sqlite4java.artifactId>
+                <sqlite4java.type>dylib</sqlite4java.type>
+            </properties>
+        </profile>
+        <profile>
+            <id>linux-x32</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <arch>i386</arch>
+                </os>
+            </activation>
+            <properties>
+                <sqlite4java.artifactId>libsqlite4java-linux-i386</sqlite4java.artifactId>
+                <sqlite4java.type>so</sqlite4java.type>
+            </properties>
+        </profile>
+        <profile>
+            <id>linux-x64</id>
+            <activation>
+                <os>
+                    <family>unix</family>
+                    <arch>amd64</arch>
+                </os>
+            </activation>
+            <properties>
+                <sqlite4java.artifactId>libsqlite4java-linux-amd64</sqlite4java.artifactId>
+                <sqlite4java.type>so</sqlite4java.type>
+            </properties>
+        </profile>
+        <profile>
+            <id>windows-x86</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                    <arch>x86</arch>
+                </os>
+            </activation>
+            <properties>
+                <sqlite4java.artifactId>libsqlite4java-win32-x86</sqlite4java.artifactId>
+                <sqlite4java.type>dll</sqlite4java.type>
+            </properties>
+        </profile>
+        <profile>
+            <id>windows-x64</id>
+            <activation>
+                <os>
+                    <family>windows</family>
+                    <arch>x64</arch>
+                </os>
+            </activation>
+            <properties>
+                <sqlite4java.artifactId>libsqlite4java-win32-x64</sqlite4java.artifactId>
+                <sqlite4java.type>dll</sqlite4java.type>
+            </properties>
+        </profile>
         <profile>
             <id>release</id>
             <build>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -33,6 +33,9 @@
       <action dev="derjust" issue="108" type="fix" date="2018-01-14">
         Opened constructor and fixed NPE in case of missing DynamoDBConfig
       </action>
+      <action dev="derjust" type="add" date="2018-01-23">
+        Allow for JUnit tests to use a in-memory DynamoDB instance
+      </action>
     </release>
     <release version="5.0.1" date="2018-01-06" description="Maintenance release">
       <action dev="derjust" issue="68" type="fix" date="2017-12-01" >

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/core/CustomerHistoryIT.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/core/CustomerHistoryIT.java
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith;
 import org.socialsignin.spring.data.dynamodb.domain.sample.CustomerHistory;
 import org.socialsignin.spring.data.dynamodb.domain.sample.CustomerHistoryRepository;
 import org.socialsignin.spring.data.dynamodb.repository.config.EnableDynamoDBRepositories;
+import org.socialsignin.spring.data.dynamodb.utils.DynamoDBResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
@@ -29,7 +30,7 @@ import static org.junit.Assert.assertEquals;
 
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes={CustomerHistoryIT.TestAppConfig.class, ConfigurationTI.class})
+@ContextConfiguration(classes={CustomerHistoryIT.TestAppConfig.class, DynamoDBResource.class})
 public class CustomerHistoryIT {
 
     @Configuration

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/core/DynamoDBTemplateIT.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/core/DynamoDBTemplateIT.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.socialsignin.spring.data.dynamodb.domain.sample.User;
+import org.socialsignin.spring.data.dynamodb.utils.DynamoDBResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -30,7 +31,7 @@ import java.util.UUID;
  * Integration test that interacts with DynamoDB Local instance.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes={ConfigurationTI.class})
+@ContextConfiguration(classes={DynamoDBResource.class})
 public class DynamoDBTemplateIT {
 
     @Autowired

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/core/FeedUserIT.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/core/FeedUserIT.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.socialsignin.spring.data.dynamodb.domain.sample.FeedUserRepository;
 import org.socialsignin.spring.data.dynamodb.repository.config.EnableDynamoDBRepositories;
+import org.socialsignin.spring.data.dynamodb.utils.DynamoDBResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.PageRequest;
@@ -28,7 +29,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes={FeedUserIT.TestAppConfig.class, ConfigurationTI.class})
+@ContextConfiguration(classes={FeedUserIT.TestAppConfig.class, DynamoDBResource.class})
 public class FeedUserIT {
 
     @Configuration

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/domain/sample/GlobalSecondaryIndexWithRangeKeyIT.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/domain/sample/GlobalSecondaryIndexWithRangeKeyIT.java
@@ -17,8 +17,8 @@ package org.socialsignin.spring.data.dynamodb.domain.sample;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.socialsignin.spring.data.dynamodb.core.ConfigurationTI;
 import org.socialsignin.spring.data.dynamodb.repository.config.EnableDynamoDBRepositories;
+import org.socialsignin.spring.data.dynamodb.utils.DynamoDBResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
@@ -38,7 +38,7 @@ import static org.junit.Assert.fail;
  * Shows the usage of Hash+Range key combinations with global secondary indexes.
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = {ConfigurationTI.class, GlobalSecondaryIndexWithRangeKeyIT.TestAppConfig.class})
+@ContextConfiguration(classes = {DynamoDBResource.class, GlobalSecondaryIndexWithRangeKeyIT.TestAppConfig.class})
 public class GlobalSecondaryIndexWithRangeKeyIT {
 
     @Configuration

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/domain/sample/Jdk8IT.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/domain/sample/Jdk8IT.java
@@ -17,8 +17,8 @@ package org.socialsignin.spring.data.dynamodb.domain.sample;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.socialsignin.spring.data.dynamodb.core.ConfigurationTI;
 import org.socialsignin.spring.data.dynamodb.repository.config.EnableDynamoDBRepositories;
+import org.socialsignin.spring.data.dynamodb.utils.DynamoDBResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertNotNull;
  * github.com/spring-projects/spring-data-examples/master/jpa/java8</a>
  */
 @RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration(classes = {ConfigurationTI.class, Jdk8IT.TestAppConfig.class})
+@ContextConfiguration(classes = {DynamoDBResource.class, Jdk8IT.TestAppConfig.class})
 public class Jdk8IT {
 
 	@Configuration

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/utils/DynamoDBLocalResource.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/utils/DynamoDBLocalResource.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright © 2013 spring-data-dynamodb (https://github.com/derjust/spring-data-dynamodb)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.socialsignin.spring.data.dynamodb.utils;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded;
+import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.CreateTableResult;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.KeyType;
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType;
+import org.junit.rules.ExternalResource;
+import org.socialsignin.spring.data.dynamodb.repository.support.DynamoDBEntityMetadataSupport;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Configuration
+public class DynamoDBLocalResource extends ExternalResource {
+
+    private AmazonDynamoDB ddb;
+
+    @Bean
+    public AmazonDynamoDB amazonDynamoDB() {
+        ddb = DynamoDBEmbedded.create().amazonDynamoDB();
+        return ddb;
+    }
+
+    public CreateTableResult createTable(Class<?> domainType) {
+        DynamoDBEntityMetadataSupport support = new DynamoDBEntityMetadataSupport(domainType);
+
+        String tableName = support.getDynamoDBTableName();
+        String hashKey = support.getHashKeyPropertyName();
+        String rangeKey = support.getHashKeyPropertyName();
+
+        return createTable(tableName, hashKey, rangeKey);
+    }
+
+    private CreateTableResult createTable(String tableName, String hashKeyName, String rangeKeyName) {
+        List<AttributeDefinition> attributeDefinitions = new ArrayList<>();
+        attributeDefinitions.add(new AttributeDefinition(hashKeyName, ScalarAttributeType.S));
+
+        List<KeySchemaElement> ks = new ArrayList<>();
+        ks.add(new KeySchemaElement(hashKeyName, KeyType.HASH));
+
+        if (rangeKeyName != null) {
+            attributeDefinitions.add(new AttributeDefinition(rangeKeyName, ScalarAttributeType.S));
+
+            ks.add(new KeySchemaElement(rangeKeyName, KeyType.RANGE));
+        }
+
+        ProvisionedThroughput provisionedthroughput = new ProvisionedThroughput(10L, 10L);
+
+        CreateTableRequest request =
+                new CreateTableRequest()
+                        .withTableName(tableName)
+                        .withAttributeDefinitions(attributeDefinitions)
+                        .withKeySchema(ks)
+                        .withProvisionedThroughput(provisionedthroughput);
+
+        return ddb.createTable(request);
+    }
+
+    @Override
+    protected void after() {
+        ddb.shutdown();
+    };
+}

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/utils/DynamoDBResource.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/utils/DynamoDBResource.java
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.socialsignin.spring.data.dynamodb.core;
+package org.socialsignin.spring.data.dynamodb.utils;
 
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.Assert;
@@ -28,7 +31,7 @@ import org.springframework.util.Assert;
  * launched local DynamoDB by Maven's integration-test.
  */
 @Configuration
-public class ConfigurationTI {
+public class DynamoDBResource {
     private static final String DYNAMODB_PORT_PROPERTY = "dynamodb.port";
     private static final String PORT = System.getProperty(DYNAMODB_PORT_PROPERTY);
 
@@ -36,9 +39,11 @@ public class ConfigurationTI {
     public AmazonDynamoDB amazonDynamoDB() {
         Assert.notNull(PORT, "System property '" + DYNAMODB_PORT_PROPERTY + " not set!");
 
-        AmazonDynamoDB dynamoDB = new AmazonDynamoDBClient(new BasicAWSCredentials("AWS-Key", ""));
-        dynamoDB.setEndpoint(String.format("http://localhost:%s", PORT));
+        AmazonDynamoDBClientBuilder builder = AmazonDynamoDBClientBuilder.standard();
+        builder.withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials("AWS-Key", "")));
+        builder.withEndpointConfiguration(
+                new AwsClientBuilder.EndpointConfiguration(String.format("http://localhost:%s", PORT), "us-east-1"));
 
-        return dynamoDB;
+        return builder.build();
     }
 }


### PR DESCRIPTION
Provides `@Configurable` annotation for JUnit tests to bootstrap a (in-memory) DynamoDB database for real-life testing of AWS SDK calls.
By no means should this replace the TI tests that aim for the standalon DynamoDB integration testing!