### PR TITLE
Followup: Handle new `Sort.unsorted()` sorting strategy

### DIFF
--- a/src/main/java/org/socialsignin/spring/data/dynamodb/mapping/event/AbstractDynamoDBEventListener.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/mapping/event/AbstractDynamoDBEventListener.java
@@ -108,6 +108,7 @@ public abstract class AbstractDynamoDBEventListener<E> implements
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	private void publishEachElement(List<?> list, Consumer<E> publishMethod) {
 		list.stream()
 				.filter(o -> domainClass.isAssignableFrom(o.getClass()))

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/query/ScanExpressionCountQuery.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/query/ScanExpressionCountQuery.java
@@ -37,7 +37,7 @@ public class ScanExpressionCountQuery<T> extends AbstractSingleEntityQuery<Long>
 	@Override
 	public Long getSingleResult() {
 		assertScanCountEnabled(isScanCountEnabled());
-		return new Long(dynamoDBOperations.count(domainClass,scanExpression));
+		return Long.valueOf(dynamoDBOperations.count(domainClass,scanExpression));
 	}
 	
 	public void assertScanCountEnabled(boolean scanCountEnabled)

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBEntityWithHashAndRangeKeyCriteria.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBEntityWithHashAndRangeKeyCriteria.java
@@ -330,7 +330,7 @@ public class DynamoDBEntityWithHashAndRangeKeyCriteria<T, ID> extends AbstractDy
 
 	public DynamoDBScanExpression buildScanExpression() {
 
-		ensureNoSort();
+		ensureNoSort(sort);
 
 		DynamoDBScanExpression scanExpression = new DynamoDBScanExpression();
 		if (isHashKeySpecified()) {

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBEntityWithHashKeyOnlyCriteria.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/query/DynamoDBEntityWithHashKeyOnlyCriteria.java
@@ -90,7 +90,7 @@ public class DynamoDBEntityWithHashKeyOnlyCriteria<T, ID> extends AbstractDynamo
 
 	public DynamoDBScanExpression buildScanExpression() {
 
-		ensureNoSort();
+		ensureNoSort(sort);
 
 		DynamoDBScanExpression scanExpression = new DynamoDBScanExpression();
 		if (isHashKeySpecified()) {

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/support/DynamoDBEntityMetadataSupport.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/support/DynamoDBEntityMetadataSupport.java
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -301,12 +302,9 @@ public class DynamoDBEntityMetadataSupport<T, ID> implements DynamoDBHashKeyExtr
 
 		if(annotation != null) {
 			try {
-				return annotation.marshallerClass().newInstance();
-			} catch (InstantiationException e) {
+				return annotation.marshallerClass().getDeclaredConstructor().newInstance();
+			} catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
 				throw new RuntimeException(e);
-			} catch (IllegalAccessException e) {
-				throw new RuntimeException(e);
-
 			}
 		}
 

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/support/DynamoDBHashAndRangeKeyExtractingEntityMetadataImpl.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/support/DynamoDBHashAndRangeKeyExtractingEntityMetadataImpl.java
@@ -24,6 +24,7 @@ import org.springframework.util.ReflectionUtils.FieldCallback;
 import org.springframework.util.ReflectionUtils.MethodCallback;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashSet;
 import java.util.Set;
@@ -109,7 +110,7 @@ public class DynamoDBHashAndRangeKeyExtractingEntityMetadataImpl<T, ID> extends
 	public T getHashKeyPropotypeEntityForHashKey(Object hashKey) {
 
 		try {
-			T entity = getJavaType().newInstance();
+			T entity = getJavaType().getDeclaredConstructor().newInstance();
 			if (hashKeySetterMethod != null)
 			{
 				ReflectionUtils.invokeMethod(hashKeySetterMethod, entity, hashKey);
@@ -120,9 +121,7 @@ public class DynamoDBHashAndRangeKeyExtractingEntityMetadataImpl<T, ID> extends
 			}
 
 			return entity;
-		} catch (InstantiationException e) {
-			throw new RuntimeException(e);
-		} catch (IllegalAccessException e) {
+		} catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
 			throw new RuntimeException(e);
 		}
 	}

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/support/SimpleDynamoDBCrudRepository.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/support/SimpleDynamoDBCrudRepository.java
@@ -22,6 +22,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.KeyPair;
 import org.socialsignin.spring.data.dynamodb.exception.BatchWriteException;
 import org.socialsignin.spring.data.dynamodb.core.DynamoDBOperations;
 import org.socialsignin.spring.data.dynamodb.repository.DynamoDBCrudRepository;
+import org.socialsignin.spring.data.dynamodb.utils.SortHandler;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.util.Assert;
@@ -46,7 +47,8 @@ import java.util.stream.StreamSupport;
  *            the type of the entity's identifier
  */
 public class SimpleDynamoDBCrudRepository<T, ID>
-		implements DynamoDBCrudRepository<T, ID> {
+		implements DynamoDBCrudRepository<T, ID>,
+		SortHandler {
 
 	protected DynamoDBEntityInformation<T, ID> entityInformation;
 

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/support/SimpleDynamoDBPagingAndSortingRepository.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/support/SimpleDynamoDBPagingAndSortingRepository.java
@@ -64,15 +64,13 @@ public class SimpleDynamoDBPagingAndSortingRepository<T, ID> extends SimpleDynam
 
 	@Override
 	public Iterable<T> findAll(Sort sort) {
-		throw new UnsupportedOperationException("Sorting not supported for find all scan operations");
+		return throwUnsupportedSortOperationException();
 	}
 
 	@Override
 	public Page<T> findAll(Pageable pageable) {
 
-		if (pageable.getSort() != null) {
-			throw new UnsupportedOperationException("Sorting not supported for find all scan operations");
-		}
+		ensureNoSort(pageable);
 
 		DynamoDBScanExpression scanExpression = new DynamoDBScanExpression();
 		// Scan to the end of the page after the requested page

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/utils/SortHandler.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/utils/SortHandler.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright © 2013 spring-data-dynamodb (https://github.com/derjust/spring-data-dynamodb)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.socialsignin.spring.data.dynamodb.utils;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+/**
+ * Some helper methods to deal with {@link Sort}.
+ *
+ * @author derjust
+ */
+public interface SortHandler {
+
+     default void ensureNoSort(Pageable pageable) {
+        Sort sort = pageable.getSort();
+        ensureNoSort(sort);
+    }
+
+    /**
+     * @throws UnsupportedOperationException if a {@code sort} is initialized (non-null &amp;&amp; not {@link Sort#unsorted()}
+     */
+    default void ensureNoSort(Sort sort) throws UnsupportedOperationException {
+        if (!Sort.unsorted().equals(sort)) {
+            throwUnsupportedSortOperationException();
+        }
+    }
+
+    default <T> T throwUnsupportedSortOperationException() {
+        throw new UnsupportedOperationException("Sorting not supported for scan expressions");
+    }
+}

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/config/DynamoDBAuditingRegistrarUnitTests.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/config/DynamoDBAuditingRegistrarUnitTests.java
@@ -18,7 +18,7 @@
     import org.junit.Test;
     import org.junit.runner.RunWith;
     import org.mockito.Mock;
-    import org.mockito.runners.MockitoJUnitRunner;
+    import org.mockito.junit.MockitoJUnitRunner;
     import org.springframework.beans.factory.support.BeanDefinitionRegistry;
     import org.springframework.core.type.AnnotationMetadata;
 

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/core/FeedUserIT.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/core/FeedUserIT.java
@@ -42,7 +42,7 @@ public class FeedUserIT {
 
     @Test
     public void feed_test(){
-        PageRequest pageRequest = new PageRequest(1, 10, new Sort(Direction.DESC, "usrNo"));
+        PageRequest pageRequest = PageRequest.of(1, 10, new Sort(Direction.DESC, "usrNo"));
         feedUserRepository.findByUsrNo(2, pageRequest); //runnable
         feedUserRepository.findByUsrNoAndFeedOpenYn(2, true, pageRequest); //not runnable
     }

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/query/AbstractMultipleEntityQueryTest.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/query/AbstractMultipleEntityQueryTest.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright © 2013 spring-data-dynamodb (https://github.com/derjust/spring-data-dynamodb)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.socialsignin.spring.data.dynamodb.query;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.socialsignin.spring.data.dynamodb.core.DynamoDBOperations;
+import org.socialsignin.spring.data.dynamodb.domain.sample.User;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractMultipleEntityQueryTest {
+
+    private static class TestAbstractMultipleEntityQuery extends AbstractMultipleEntityQuery<User> {
+        private final List<User> resultList;
+
+        public TestAbstractMultipleEntityQuery(DynamoDBOperations dynamoDBOperations, User... resultEntities) {
+            super(dynamoDBOperations, User.class);
+            resultList = Arrays.asList(resultEntities);
+        }
+
+        @Override
+        public List<User> getResultList() {
+            return resultList;
+        }
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private DynamoDBOperations dynamoDBOperations;
+    @Mock
+    private User entity;
+
+    private AbstractMultipleEntityQuery underTest;
+
+    @Test
+    public void testNullResult() {
+        underTest = new TestAbstractMultipleEntityQuery(dynamoDBOperations, new User[]{null});
+
+        assertNull(underTest.getSingleResult());
+    }
+
+    @Test
+    public void testSingleResult() {
+        underTest = new TestAbstractMultipleEntityQuery(dynamoDBOperations, entity);
+
+        assertSame(entity, underTest.getSingleResult());
+    }
+
+    @Test
+    public void testMultiResult() {
+        expectedException.expect(IncorrectResultSizeDataAccessException.class);
+        underTest = new TestAbstractMultipleEntityQuery(dynamoDBOperations, entity, entity);
+
+        underTest.getSingleResult();
+    }
+}

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/query/ScanExpressionCountQueryTest.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/query/ScanExpressionCountQueryTest.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright © 2013 spring-data-dynamodb (https://github.com/derjust/spring-data-dynamodb)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.socialsignin.spring.data.dynamodb.query;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBScanExpression;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.socialsignin.spring.data.dynamodb.core.DynamoDBOperations;
+import org.socialsignin.spring.data.dynamodb.domain.sample.User;
+
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ScanExpressionCountQueryTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private DynamoDBOperations dynamoDBOperations;
+    @Mock
+    private DynamoDBScanExpression scanExpression;
+
+    private ScanExpressionCountQuery<User> underTest;
+
+    @Test
+    public void testScanCountEnabledTrueTrue() {
+        underTest = new ScanExpressionCountQuery<>(dynamoDBOperations, User.class, scanExpression, true);
+
+        underTest.assertScanCountEnabled(true);
+
+        assertTrue(true);
+    }
+
+    @Test
+    public void testScanCountEnabledTrueFalse() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Scanning for the total counts for this query is not enabled. " +
+                " To enable annotate your repository method with @EnableScanCount, or enable scanning for all repository methods by annotating your repository interface with @EnableScanCount. " +
+                " This total count is required to serve this Page query - if total counts are not desired an alternative approach could be to replace the Page query with a Slice query ");
+        underTest = new ScanExpressionCountQuery<>(dynamoDBOperations, User.class, scanExpression, true);
+
+        underTest.assertScanCountEnabled(false);
+    }
+
+    @Test
+    public void testScanCountEnabledFalseTrue() {
+        underTest = new ScanExpressionCountQuery<>(dynamoDBOperations, User.class, scanExpression, false);
+
+        underTest.assertScanCountEnabled(true);
+
+        assertTrue(true);
+    }
+
+    @Test
+    public void testScanCountEnabledFalseFalse() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Scanning for counts for this query is not enabled. " +
+                " To enable annotate your repository method with @EnableScanCount, or enable scanning for all repository methods by annotating your repository interface with @EnableScanCount");
+        underTest = new ScanExpressionCountQuery<>(dynamoDBOperations, User.class, scanExpression, false);
+
+        underTest.assertScanCountEnabled(false);
+    }
+}

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/utils/DynamoDBLocalResource.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/utils/DynamoDBLocalResource.java
@@ -47,14 +47,13 @@ public class DynamoDBLocalResource extends ExternalResource {
         return ddb;
     }
 
-    public static CreateTableResult createTable(AmazonDynamoDB ddb, Class<?> domainType) {
-        DynamoDBEntityMetadataSupport support = new DynamoDBEntityMetadataSupport(domainType);
-        DynamoDBEntityInformation entityInfo = support.getEntityInformation();
+    public static <T> CreateTableResult createTable(AmazonDynamoDB ddb, Class<T> domainType) {
+        DynamoDBEntityMetadataSupport<T, Object> support = new DynamoDBEntityMetadataSupport(domainType);
+        DynamoDBEntityInformation<T, Object> entityInfo = support.getEntityInformation();
 
         String tableName = entityInfo.getDynamoDBTableName();
         String hashKey = entityInfo.getHashKeyPropertyName();
-        Optional<String> columnName = entityInfo.getOverriddenAttributeName(hashKey);
-        hashKey = columnName.orElse(hashKey);
+        hashKey = entityInfo.getOverriddenAttributeName(hashKey).orElse(hashKey);
 
         Optional<String> rangeKey = Optional.empty();
         if (entityInfo instanceof DynamoDBIdIsHashAndRangeKeyEntityInformation) {


### PR DESCRIPTION
Spring-Data no longer passes in `null` if no sorting order is given by the caller but uses `Sort.unsorted()` which incorrectly causes an Exception.
This should also solve #99

Followup to 8c3e139246c4a9617b0d7c22b5a170fb2d42f261

Also getting rid of some JDK9 deprecated warnings on the JDK classes - as those methods exist in JDK8 already.