### PR TITLE
Issue #146 - Initialize DynamoDBMapperConfigs that are missing required fields

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -30,6 +30,12 @@
       <action dev="derjust" issue="142" type="add" date="2018-03-21">
         Added support for @Query-based projections
       </action>
+      <action dev="derjust" issue="148" type="add" date="2018-03-22">
+        Publish master builds to OSSRH as SNAPSHOT
+      </action>
+      <action dev="derjust" issue="146" type="fix" date="2018-03-24">
+        Fix incomplete AWS DynamoDBMapper initialization
+      </action>
     </release>
     <release version="5.0.2" date="2018-03-05" description="Maintenance release">
       <action dev="vitolimandibhrata" issue="40" type="add" date="2017-01-07">

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/core/DynamoDBTemplate.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/core/DynamoDBTemplate.java
@@ -86,20 +86,20 @@ public class DynamoDBTemplate implements DynamoDBOperations, ApplicationContextA
      * @param dynamoDBMapperConfig can be {@code null} - {@link DynamoDBMapperConfig#DEFAULT} is used if {@code null} is passed in
      * @param dynamoDBMapper can be {@code null} - {@link DynamoDBMapper#DynamoDBMapper(AmazonDynamoDB, DynamoDBMapperConfig)} is used if {@code null} is passed in */
 	public DynamoDBTemplate(AmazonDynamoDB amazonDynamoDB, DynamoDBMapperConfig dynamoDBMapperConfig, DynamoDBMapper dynamoDBMapper) {
-       Assert.notNull(amazonDynamoDB, "amazonDynamoDB must not be null!");
-	   this.amazonDynamoDB = amazonDynamoDB;
-	   
-	  if (dynamoDBMapperConfig == null) {
-		  this.dynamoDBMapperConfig = DynamoDBMapperConfig.DEFAULT;		  
-	  } else {
-		  this.dynamoDBMapperConfig = dynamoDBMapperConfig;
-	  }
-	  
-	  if (dynamoDBMapper == null) {
-          this.dynamoDBMapper = new DynamoDBMapper(amazonDynamoDB, dynamoDBMapperConfig);
-	  } else {
-          this.dynamoDBMapper = dynamoDBMapper;
-	  }
+		Assert.notNull(amazonDynamoDB, "amazonDynamoDB must not be null!");
+		this.amazonDynamoDB = amazonDynamoDB;
+
+		if (dynamoDBMapperConfig == null) {
+			this.dynamoDBMapperConfig = DynamoDBMapperConfig.DEFAULT;
+		} else {
+			this.dynamoDBMapperConfig = dynamoDBMapperConfig;
+		}
+
+		if (dynamoDBMapper == null) {
+			this.dynamoDBMapper = new DynamoDBMapper(amazonDynamoDB, dynamoDBMapperConfig);
+		} else {
+			this.dynamoDBMapper = dynamoDBMapper;
+		}
     }
 	
 	@Override


### PR DESCRIPTION
The old documentation at https://github.com/derjust/spring-data-dynamodb/wiki/Alter-table-name-during-runtime (Same as https://git.io/DynamoDBMapperConfig) told people to start with an empty Builder.
This causes issues down the line as required fields (TypeConverterFactory & ConversionSchema) where not properly initialized