### PR TITLE
Fix for Issue #15.

### DIFF
--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/config/DynamoDBRepositoryConfigExtension.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/config/DynamoDBRepositoryConfigExtension.java
@@ -15,6 +15,7 @@
  */
 package org.socialsignin.spring.data.dynamodb.repository.config;
 
+import org.socialsignin.spring.data.dynamodb.mapping.DynamoDBMappingContext;
 import org.socialsignin.spring.data.dynamodb.repository.support.DynamoDBRepositoryFactoryBean;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.core.annotation.AnnotationAttributes;
@@ -40,6 +41,8 @@ public class DynamoDBRepositoryConfigExtension extends RepositoryConfigurationEx
 
 	private static final String AMAZON_DYNAMODB_REF = "amazon-dynamodb-ref";
 
+	private static final String MAPPING_CONTEXT_REF = "mapping-context-ref";
+
 	@Override
 	public String getRepositoryFactoryBeanClassName() {
 		return DynamoDBRepositoryFactoryBean.class.getName();
@@ -50,7 +53,7 @@ public class DynamoDBRepositoryConfigExtension extends RepositoryConfigurationEx
 		AnnotationAttributes attributes = config.getAttributes();
 
 		postProcess(builder, attributes.getString("amazonDynamoDBRef"), attributes.getString("dynamoDBMapperConfigRef"),
-				attributes.getString("dynamoDBOperationsRef"));
+				attributes.getString("dynamoDBOperationsRef"), attributes.getString("mappingContextRef"));
 
 	}
 
@@ -71,11 +74,12 @@ public class DynamoDBRepositoryConfigExtension extends RepositoryConfigurationEx
 		ParsingUtils.setPropertyReference(builder, element, AMAZON_DYNAMODB_REF, "amazonDynamoDB");
 		ParsingUtils.setPropertyReference(builder, element, DYNAMO_DB_MAPPER_CONFIG_REF, "dynamoDBMapperConfig");
 		ParsingUtils.setPropertyReference(builder, element, DYNAMO_DB_OPERATIONS_REF, "dynamoDBOperations");
+		ParsingUtils.setPropertyReference(builder, element, MAPPING_CONTEXT_REF, "dynamoDBMappingContext");
 
 	}
 
 	private void postProcess(BeanDefinitionBuilder builder, String amazonDynamoDBRef, String dynamoDBMapperConfigRef,
-			String dynamoDBOperationsRef) {
+			String dynamoDBOperationsRef, String dynamoDBMappingContextRef) {
 
 		if (StringUtils.hasText(dynamoDBOperationsRef)) {
 			builder.addPropertyReference("dynamoDBOperations", dynamoDBOperationsRef);
@@ -96,6 +100,11 @@ public class DynamoDBRepositoryConfigExtension extends RepositoryConfigurationEx
 			}
 		}
 
+		if (StringUtils.hasText(dynamoDBMappingContextRef)) {
+			builder.addPropertyReference("dynamoDBMappingContext", dynamoDBMappingContextRef);
+		} else {
+			builder.addPropertyValue("dynamoDBMappingContext", new DynamoDBMappingContext());
+		}
 	}
 
 	@Override

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/config/EnableDynamoDBRepositories.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/config/EnableDynamoDBRepositories.java
@@ -157,4 +157,16 @@ public @interface EnableDynamoDBRepositories {
 	 */
 	String dynamoDBOperationsRef() default "";
 
+	/**
+	 * Returns the
+	 * {@link org.socialsignin.spring.data.dynamodb.mapping.DynamoDBMappingContext}
+	 * reference for the
+	 * {@link org.springframework.data.mapping.context.MappingContext} for
+	 * AmazonDynamoDB.
+	 *
+	 * @return The
+	 *         {@link org.socialsignin.spring.data.dynamodb.mapping.DynamoDBMappingContext}
+	 *         bean name
+	 */
+	String mappingContextRef() default "";
 }

--- a/src/main/java/org/socialsignin/spring/data/dynamodb/repository/support/DynamoDBRepositoryFactoryBean.java
+++ b/src/main/java/org/socialsignin/spring/data/dynamodb/repository/support/DynamoDBRepositoryFactoryBean.java
@@ -59,8 +59,6 @@ public class DynamoDBRepositoryFactoryBean<T extends Repository<S, ID>, S, ID ex
 
 	public void setAmazonDynamoDB(AmazonDynamoDB amazonDynamoDB) {
 		this.amazonDynamoDB = amazonDynamoDB;
-		setMappingContext(new DynamoDBMappingContext());
-
 	}
 
 	@Override
@@ -88,6 +86,9 @@ public class DynamoDBRepositoryFactoryBean<T extends Repository<S, ID>, S, ID ex
 
 	public void setDynamoDBOperations(DynamoDBOperations dynamoDBOperations) {
 		this.dynamoDBOperations = dynamoDBOperations;
-		setMappingContext(new DynamoDBMappingContext());
+	}
+
+	public void setDynamoDBMappingContext(DynamoDBMappingContext dynamoDBMappingContext) {
+		setMappingContext(dynamoDBMappingContext);
 	}
 }

--- a/src/main/resources/org/socialsignin/spring/data/dynamodb/repository/config/spring-dynamodb-1.0.xsd
+++ b/src/main/resources/org/socialsignin/spring/data/dynamodb/repository/config/spring-dynamodb-1.0.xsd
@@ -36,6 +36,7 @@
 					<xsd:attribute name="amazon-dynamodb-ref" type="amazonDynamoDBRef" use="optional" />
 					<xsd:attribute name="dynamodb-mapper-config-ref" type="dynamoDBMapperConfigRef" use="optional"/>
 					<xsd:attribute name="dynamodb-operations-ref" type="dynamoDBOperationsRef" use="optional"/>
+					<xsd:attribute name="mapping-context-ref" type="mappingContextRef" use="optional" />
 				</xsd:extension>
 			</xsd:complexContent>
 		</xsd:complexType>

--- a/src/test/java/org/socialsignin/spring/data/dynamodb/repository/support/DynamoDBRepositoryFactoryBeanTest.java
+++ b/src/test/java/org/socialsignin/spring/data/dynamodb/repository/support/DynamoDBRepositoryFactoryBeanTest.java
@@ -17,6 +17,7 @@ package org.socialsignin.spring.data.dynamodb.repository.support;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,6 +25,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.socialsignin.spring.data.dynamodb.core.DynamoDBOperations;
 import org.socialsignin.spring.data.dynamodb.domain.sample.User;
+import org.socialsignin.spring.data.dynamodb.mapping.DynamoDBMappingContext;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.repository.Repository;
 
@@ -44,6 +46,8 @@ public class DynamoDBRepositoryFactoryBeanTest {
 	@Mock
 	private AmazonDynamoDB amazonDynamoDB;
 
+	private DynamoDBMappingContext dynamoDBMappingContext = new DynamoDBMappingContext();
+
 	private DynamoDBRepositoryFactoryBean underTest;
 
 	public interface UserRepository extends Repository<User, String> {
@@ -55,6 +59,7 @@ public class DynamoDBRepositoryFactoryBeanTest {
 		underTest = spy(new DynamoDBRepositoryFactoryBean(UserRepository.class));
 		underTest.setApplicationContext(applicationContext);
 		underTest.setDynamoDBMapperConfig(dynamoDBMapperConfig);
+		underTest.setDynamoDBMappingContext(dynamoDBMappingContext);
 	}
 
 	@Test


### PR DESCRIPTION
Spring Data Rest uses a PersistentEntityResourceAssembler that requires the DynamoDBMappingContext to be exposed as a Spring Bean. 

The Spring Configuration should create this bean
```java    
@Bean
public DynamoDBMappingContext dynamoDBMappingContext() {
    return new DynamoDBMappingContext();
}
```

then declared in the EnableDynamoDBRepositories annotation
```java
@EnableDynamoDBRepositories(basePackages = "my.packages", dynamoDBOperationsRef="dynamoDBOperations", mappingContextRef = "dynamoDBMappingContext")

```

This solves issue #15 